### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/validate_repositories_py_file.yaml
+++ b/.github/workflows/validate_repositories_py_file.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Update to actions v4, to update to the Node 20 runtime. This will fix the warning caused by actions v3 using the Node 16 runtime.

See here: 
 - https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/#for-actions-users
 - https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/